### PR TITLE
GHA: update several GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: ./.github/workflows
+    schedule:
+      interval: weekly

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download plan
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.planName }}
           path: ${{ inputs.envPath }}

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run terraform plan
         env:
@@ -59,7 +59,7 @@ jobs:
              terraform plan -out=${{ inputs.planName }}
 
       - name: 'Upload Plan'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.planName }}
           path: ${{ inputs.envPath }}/${{ inputs.planName }}

--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run checkov scan on ${{ inputs.envPath }}
         run: checkov --quiet --compact -d ${{ inputs.envPath }}
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run terraform fmt
         run: terraform fmt -recursive -check -diff
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run terraform validate
         env:


### PR DESCRIPTION
* Updates `actions/checkout@v2` to `actions/checkout@v4`
* Updates `actions/upload-artifact@v3` to `actions/upload-artifact@v4`
* Updates `actions/download-artifact@v3` to `actions/download-artifact@v4`
* Introduces Dependabot configured to check GHA updates on a weekly basis